### PR TITLE
Typo fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 module.exports = {
     World   : require('./core/World'),
-    plugins : require('./core/Plugins'),
+    plugins : require('./core/plugins'),
 }


### PR DESCRIPTION
I think there's a typo, since plugins folder name has only lowercase letters.
